### PR TITLE
Fix some bugs for training with triplet, add training log module, and add more default data support.

### DIFF
--- a/common/train_logger.py
+++ b/common/train_logger.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+import time
+
+def loginfo(log_dir):
+    log_time_name = time.strftime('train_log_%Y_%m_%d_%H_%M_%S', time.localtime(time.time()))
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logfile = os.path.join(log_dir, '%s.txt' % log_time_name)
+    fh = logging.FileHandler(logfile, mode='w')
+    fh.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)-15s %(message)s')
+    fh.setFormatter(formatter)
+    ch.setFormatter(formatter)
+    logger.addHandler(fh)
+    logger.addHandler(ch)

--- a/recognition/sample_config.py
+++ b/recognition/sample_config.py
@@ -120,6 +120,20 @@ dataset.retina.num_classes = 93431
 dataset.retina.image_shape = (112,112,3)
 dataset.retina.val_targets = ['lfw', 'cfp_fp', 'agedb_30']
 
+dataset.glintasia = edict()
+dataset.glintasia.dataset = 'glintasia'
+dataset.glintasia.dataset_path = '../datasets/faces_glintasia'
+dataset.glintasia.num_classes = 93979
+dataset.glintasia.image_shape = (112,112,3)
+dataset.glintasia.val_targets = ['lfw', 'cfp_fp', 'agedb_30']
+
+dataset.glint = edict()
+dataset.glint.dataset = 'glint'
+dataset.glint.dataset_path = '../datasets/faces_glint'
+dataset.glint.num_classes = 180855
+dataset.glint.image_shape = (112,112,3)
+dataset.glint.val_targets = ['lfw', 'cfp_fp', 'agedb_30']
+
 loss = edict()
 loss.softmax = edict()
 loss.softmax.loss_name = 'softmax'
@@ -192,6 +206,7 @@ default.per_batch_size = 128
 default.ckpt = 3
 default.lr_steps = '100000,160000,220000'
 default.models_root = './models'
+default.log_dir = './models/'
 
 
 def generate_config(_network, _dataset, _loss):

--- a/recognition/train_triplet.py
+++ b/recognition/train_triplet.py
@@ -215,7 +215,7 @@ def train_net(args):
         symbol        = sym,
     )
     # model.bind() for triplet loss fine-tuning to fix the AssertionError: assert self.binded and self.params_initialized
-    # model.bind([("data", (args.batch_size, args.image_channel, image_size[0], image_size[1]))], [("softmax_label", (args.batch_size,))])
+    model.bind([("data", (args.batch_size, args.image_channel, image_size[0], image_size[1]))], [("softmax_label", (args.batch_size,))])
     val_dataiter = None
 
     if config.loss_name.find('triplet')>=0:

--- a/recognition/triplet_image_iter.py
+++ b/recognition/triplet_image_iter.py
@@ -180,7 +180,7 @@ class FaceImageIter(io.DataIter):
       self.triplet_seq = []
       for _id in ids:
         v = self.id2range[_id]
-        _list = range(*v)
+        _list = list(range(*v))
         random.shuffle(_list)
         if len(_list)>self.images_per_identity:
           _list = _list[0:self.images_per_identity]


### PR DESCRIPTION
1. Modify the ```_list = range(*v)```to```_list = list(range(*v))``` in module of ```triplet_image_iter.py``` to support python3.
2. Add a module of ```train_logger.py``` in directory of ```commom``` to support logging function.
3. Use logging function in ```recognition/train.py```.
4. Add ```model.bind()``` in  ```recognition/train_triplet.py```for triplet loss fine-tuning to fix the **AssertionError: assert self.binded and self.params_initialized**.
5. Add more default data support in ```recognition/sample_config.py```, including```emore``` ```retina``` ```glintasia``` ```glint```.