### PR TITLE
Fix a bug in face_align.py

### DIFF
--- a/common/face_align.py
+++ b/common/face_align.py
@@ -65,7 +65,7 @@ def estimate_norm(lmk, image_size = 112, mode='arcface'):
   min_error = float('inf') 
   if mode=='arcface':
     assert image_size==112
-    src = arcface_src
+    src = np.array([arcface_src])
   else:
     src = src_map[image_size]
   for i in np.arange(src.shape[0]):


### PR DESCRIPTION
Hi. I'm Lee
First of all, thank you for your great works! It's very helpful to me.
I found a bug in face_align.py.
https://github.com/deepinsight/insightface/blob/be3f7b3e0e635b56d903d845640b048247c41c90/common/face_align.py#L68

when i select `mode=='arcface'` and exec `tform.estimate(lmk, src[i])`, ValueError is occur because shape of `src` is not like `(1, 5, 2)` but just `(5, 2)`. 
```
ValueError: shapes (2,) and (5,2) not aligned: 2 (dim 0) != 5 (dim 0)
```
so i modified the line that get into trouble provisionally. (just make it np.array form)

thank you