### PR TITLE
Add path for metric in train.py

### DIFF
--- a/recognition/ArcFace/train.py
+++ b/recognition/ArcFace/train.py
@@ -15,6 +15,7 @@ from mxnet import ndarray as nd
 import argparse
 import mxnet.optimizer as optimizer
 from config import config, default, generate_config
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'SubCenter-ArcFace'))
 from metric import *
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'common'))
 import flops_counter


### PR DESCRIPTION
metric.py is not recognized in train.py, because it is in SubCenter-ArcFace folder, so this addition fix this problem.