### PR TITLE
Feature: model save interval = config.verbose and code sync script

### DIFF
--- a/recognition/partial_fc/mxnet/callbacks.py
+++ b/recognition/partial_fc/mxnet/callbacks.py
@@ -92,19 +92,20 @@ class CallBackCenterSave(object):
 
 
 class CallBackModelSave(object):
-    def __init__(self, symbol, model, prefix, rank):
+    def __init__(self, symbol, model, prefix, rank, save_interval=10000):
         self.symbol = symbol
         self.model = model
         self.prefix = prefix
         self.max_step = config.max_update
         self.rank = rank
+        self.save_interval = save_interval
 
     def __call__(self, param):
         num_update = param.num_update
 
         if num_update in [
                 self.max_step - 10,
-        ] or (num_update % 10000 == 0 and num_update > 0):
+        ] or (num_update % self.save_interval == 0 and num_update > 0):
 
             # params
             arg, aux = self.model.get_export_params()

--- a/recognition/partial_fc/mxnet/sync_code.bash
+++ b/recognition/partial_fc/mxnet/sync_code.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -xu
+
+file=$1
+hosts=$( cat $file | cut -d " " -f 1 )
+
+for host in $hosts
+do
+	rsync -az ~/insightface_branch/* $host:~/insightface_branch
+done

--- a/recognition/partial_fc/mxnet/sync_code.bash
+++ b/recognition/partial_fc/mxnet/sync_code.bash
@@ -7,5 +7,5 @@ hosts=$( cat $file | cut -d " " -f 1 )
 
 for host in $hosts
 do
-	rsync -az ~/insightface_branch/* $host:~/insightface_branch
+	rsync -az ~/insightface* $host:~/insightface
 done

--- a/recognition/partial_fc/mxnet/train_memory.py
+++ b/recognition/partial_fc/mxnet/train_memory.py
@@ -158,7 +158,7 @@ def train_net():
     if not config.debug and local_rank == 0:
         cb_vert = CallBackVertification(esym, train_module)
     cb_speed = CallBackLogging(rank, size, prefix_dir)
-    cb_save = CallBackModelSave(save_symbol, train_module, prefix, rank)
+    cb_save = CallBackModelSave(save_symbol, train_module, prefix, rank, save_interval=config.verbose)
     cb_center_save = CallBackCenterSave(memory_bank)
 
     def call_back_fn(params):


### PR DESCRIPTION
I just slightly modified `callbacks.py` and `train_memory.py` so that the number of steps between saving the model is the same as `config.verbose` parameter; so the model will be saved after each validation. It's worth also checking that the validation accuracy improved since the last time the model was saved. 

I included a simple script for syncing the code across all the compute nodes, it uses the `host/host_x` files to automatically `rsync` the code.