### PR TITLE
Add ability to pass additional args such as 'root' to FaceAnalysis constructor

### DIFF
--- a/python-package/insightface/app/face_analysis.py
+++ b/python-package/insightface/app/face_analysis.py
@@ -21,15 +21,16 @@ class FaceAnalysis:
     def __init__(self,
                  det_name='retinaface_r50_v1',
                  rec_name='arcface_r100_v1',
-                 ga_name='genderage_v1'):
+                 ga_name='genderage_v1',
+                 **kwargs):
         assert det_name is not None
-        self.det_model = model_zoo.get_model(det_name)
+        self.det_model = model_zoo.get_model(det_name, **kwargs)
         if rec_name is not None:
-            self.rec_model = model_zoo.get_model(rec_name)
+            self.rec_model = model_zoo.get_model(rec_name, **kwargs)
         else:
             self.rec_model = None
         if ga_name is not None:
-            self.ga_model = model_zoo.get_model(ga_name)
+            self.ga_model = model_zoo.get_model(ga_name, **kwargs)
         else:
             self.ga_model = None
 


### PR DESCRIPTION
Add ability to pass additional args such as 'root' to FaceAnalysis constructor, so they do not have to put the model files in their home directory

Example:
```
model = insightface.app.FaceAnalysis(root='./models')
ctx_id = -1
model.prepare(ctx_id=ctx_id, nms=0.4)
```