### PR TITLE
Catch Module Not Found Error for Pypandoc

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
-except (IOError, ImportError):
+except (IOError, ImportError, ModuleNotFoundError):
     long_description = open('README.md').read()
 
 #import pypandoc


### PR DESCRIPTION
Installation of pypandoc should not be required for installing the python package, it is only required for the readme.
However when it is not installed it might throw a moduleNotFoundError which should be catched also.