### PR TITLE
Provide possibility to add onnxruntime provider

### DIFF
--- a/python-package/insightface/app/face_analysis.py
+++ b/python-package/insightface/app/face_analysis.py
@@ -6,23 +6,22 @@
 
 
 from __future__ import division
-import collections
-import numpy as np
+
 import glob
-import os
 import os.path as osp
-from numpy.linalg import norm
+
+import numpy as np
 import onnxruntime
+from numpy.linalg import norm
+
 from ..model_zoo import model_zoo
-from ..utils import face_align
-from ..utils import ensure_available
+from ..utils import DEFAULT_MP_NAME, ensure_available
 from .common import Face
-from ..utils import DEFAULT_MP_NAME
 
 __all__ = ['FaceAnalysis']
 
 class FaceAnalysis:
-    def __init__(self, name=DEFAULT_MP_NAME, root='~/.insightface', allowed_modules=None):
+    def __init__(self, name=DEFAULT_MP_NAME, root='~/.insightface', allowed_modules=None, **kwargs):
         onnxruntime.set_default_logger_severity(3)
         self.models = {}
         self.model_dir = ensure_available('models', name, root=root)
@@ -32,7 +31,8 @@ class FaceAnalysis:
             if onnx_file.find('_selfgen_')>0:
                 #print('ignore:', onnx_file)
                 continue
-            model = model_zoo.get_model(onnx_file)
+            model = model_zoo.get_model(onnx_file, **kwargs)
+
             if model is None:
                 print('model not recognized:', onnx_file)
             elif allowed_modules is not None and model.taskname not in allowed_modules:

--- a/python-package/insightface/model_zoo/model_zoo.py
+++ b/python-package/insightface/model_zoo/model_zoo.py
@@ -22,12 +22,13 @@ class ModelRouter:
     def __init__(self, onnx_file):
         self.onnx_file = onnx_file
 
-    def get_model(self):
-        session = onnxruntime.InferenceSession(self.onnx_file, None)
+    def get_model(self, **kwargs):
+        session = onnxruntime.InferenceSession(self.onnx_file, **kwargs)
+        print(f'Applied providers: {session._providers}, with options: {session._provider_options}')
         input_cfg = session.get_inputs()[0]
         input_shape = input_cfg.shape
         outputs = session.get_outputs()
-        #print(input_shape)
+
         if len(outputs)>=5:
             return SCRFD(model_file=self.onnx_file, session=session)
         elif input_shape[2]==112 and input_shape[3]==112:
@@ -66,6 +67,6 @@ def get_model(name, **kwargs):
     assert osp.exists(model_file), 'model_file should exist'
     assert osp.isfile(model_file), 'model_file should be file'
     router = ModelRouter(model_file)
-    model = router.get_model()
+    model = router.get_model(providers=kwargs.get('providers'), provider_options=kwargs.get('provider_options'))
     return model
 


### PR DESCRIPTION
If not defined otherwise the FaceAnalysis blocks the whole GPU memory although not required by the models.

Onnxruntime provides the possibility to limit the memory used by a process by passing the `provider` and `provider_options` parameter:

https://onnxruntime.ai/docs/reference/execution-providers/CUDA-ExecutionProvider.html

However according to the Docstrings of onnxruntime-gpu 1.8.1 this is not the exact correct way to pass it:

``` python
class InferenceSession(Session):
    """
    This is the main class used to run a model.
    """
    def __init__(self, path_or_bytes, sess_options=None, providers=None, provider_options=None, **kwargs):
        """
        :param path_or_bytes: filename or serialized ONNX or ORT format model in a byte string
        :param sess_options: session options
        :param providers: Optional sequence of providers in order of decreasing
            precedence. Values can either be provider names or tuples of
            (provider name, options dict). If not provided, then all available
            providers are used with the default precedence.
        :param provider_options: Optional sequence of options dicts corresponding
            to the providers listed in 'providers'.
```

Giving the developer the right to pass its own options for this parameter would improve the way of using the package in my opinion.

An example call would look like:

``` python
  self.model = FaceAnalysis(
                root='path/to/models/'
                providers=["CUDAExecutionProvider"],
                provider_options=[{"device_id": 0, 
                                   "gpu_mem_limit": gpu_mem_limit*1024*1024,
                                   'cudnn_conv_algo_search': 'HEURISTIC'}],)
```
This is an really easy implementation as it assigns the same amount of memory for each of the models, providing different options for each model would also be possible however would also require some more changes