### PR TITLE
Add output names and fix batch dim onnx export

### DIFF
--- a/detection/scrfd/mmdet/models/dense_heads/scrfd_head.py
+++ b/detection/scrfd/mmdet/models/dense_heads/scrfd_head.py
@@ -330,9 +330,12 @@ class SCRFDHead(AnchorHead):
             #    bbox_pred = bbox_pred.reshape(1, 4, -1).permute(0, 2, 1)
             #kps_pred = kps_pred.reshape(1, 10, -1).permute(0, 2, 1)
 
-            cls_score = cls_score.permute(2, 3, 0, 1).reshape(-1, self.cls_out_channels).sigmoid()
-            bbox_pred = bbox_pred.permute(2, 3, 0, 1).reshape(-1, 4)
-            kps_pred = kps_pred.permute(2,3,0,1).reshape(-1, 10)
+            # Add output batch dim, based on pull request #1593
+            batch_size = cls_score.shape[0]
+            cls_score = cls_score.permute(0, 2, 3, 1).reshape(batch_size, -1, self.cls_out_channels).sigmoid()
+            bbox_pred = bbox_pred.permute(0, 2, 3, 1).reshape(batch_size, -1, 4)
+            kps_pred = kps_pred.permute(0, 2, 3, 1).reshape(batch_size, -1, 10)
+
         return cls_score, bbox_pred, kps_pred
 
     def forward_train(self,

--- a/python-package/insightface/model_zoo/scrfd.py
+++ b/python-package/insightface/model_zoo/scrfd.py
@@ -75,6 +75,7 @@ class SCRFD:
         self.model_file = model_file
         self.session = session
         self.taskname = 'detection'
+        self.batched = False
         if self.session is None:
             assert self.model_file is not None
             assert osp.exists(self.model_file)
@@ -96,6 +97,8 @@ class SCRFD:
         input_name = input_cfg.name
         self.input_shape = input_shape
         outputs = self.session.get_outputs()
+        if len(outputs[0].shape) == 3:
+            self.batched = True
         output_names = []
         for o in outputs:
             output_names.append(o.name)
@@ -155,11 +158,21 @@ class SCRFD:
         input_width = blob.shape[3]
         fmc = self.fmc
         for idx, stride in enumerate(self._feat_stride_fpn):
-            scores = net_outs[idx]
-            bbox_preds = net_outs[idx+fmc]
-            bbox_preds = bbox_preds * stride
-            if self.use_kps:
-                kps_preds = net_outs[idx+fmc*2] * stride
+            # If model support batch dim, take first output
+            if self.batched:
+                scores = net_outs[idx][0]
+                bbox_preds = net_outs[idx + fmc][0]
+                bbox_preds = bbox_preds * stride
+                if self.use_kps:
+                    kps_preds = net_outs[idx + fmc * 2][0] * stride
+            # If model doesn't support batching take output as is
+            else:
+                scores = net_outs[idx]
+                bbox_preds = net_outs[idx + fmc]
+                bbox_preds = bbox_preds * stride
+                if self.use_kps:
+                    kps_preds = net_outs[idx + fmc * 2] * stride
+
             height = input_height // stride
             width = input_width // stride
             K = height * width


### PR DESCRIPTION
This commit is based on pull requests #1593 and #1680 with some improvements:

1. Output names are assigned taking into account optional keypoints outputs.
2. Modification to `scrfd_head.py` now allows to export model with any batch size, not only 1.

Fixes to `scrfd2onnx.py` also include defining dynamic input and output axes.
In original script dynamic axes were applied only to inputs, which caused fixed output shapes, i.e for 640x640 input size outputs for stride 8 would have output shapes: 12800x1,12800x4,12800x10:

![Screenshot from 2021-10-10 16-52-22](https://user-images.githubusercontent.com/17834919/136698662-69be537a-b0cb-432c-9f50-6a2f49e4a364.png)

Which can cause warnings during inference if input shape is different from 640x640:
```
[W:onnxruntime:, execution_frame.cc:770 VerifyOutputSizes]  Expected shape from model of {12800,1} does not match actual shape of {11552,1} for output 448
```

After proposed fix output shapes are: ?x?x1, ?x?x4, ?x?x10:

![Screenshot from 2021-10-10 16-52-12](https://user-images.githubusercontent.com/17834919/136698701-012681db-9da3-473c-a256-9a8f84953d3e.png)


And finally, added batch dimension requires changes to inference code. 
I have added output shape check to make `scrfd.py` compatible with models exported with original script (i.e python package models) as well as with models exported with proposed fixes.
Batch inference might be beneficial when using Triton inference Server with dynamic batching.


To sum up , proposed fixes make possible:
1. Suppress warnings during inference with onnxruntime.
2. Adds human readable output names consistent between models (scrfd_10g, scrfd_2.5g, etc)
3. Allow batch inference.
4. Make models compatible with Triton Inference Server by providing output batch dim.



