### PR TITLE
Make onnx inferenceSession Pickable!

### DIFF
--- a/python-package/insightface/model_zoo/model_zoo.py
+++ b/python-package/insightface/model_zoo/model_zoo.py
@@ -49,7 +49,7 @@ class ModelRouter:
         self.onnx_file = onnx_file
 
     def get_model(self, **kwargs):
-        session = onnxruntime.InferenceSession(self.onnx_file, **kwargs)
+        session = PickableInferenceSession(self.onnx_file, **kwargs)
         print(f'Applied providers: {session._providers}, with options: {session._provider_options}')
         input_cfg = session.get_inputs()[0]
         input_shape = input_cfg.shape

--- a/python-package/insightface/model_zoo/model_zoo.py
+++ b/python-package/insightface/model_zoo/model_zoo.py
@@ -18,6 +18,32 @@ from ..utils import download_onnx
 __all__ = ['get_model']
 
 
+def init_session(model_path, **kwargs):
+    sess = onnxruntime.InferenceSession(model_path,**kwargs)
+    return sess
+
+class PickableInferenceSession: 
+    # This is a wrapper to make the current InferenceSession class pickable.
+    def __init__(self, model_path, **kwargs):
+        self.model_path = model_path
+        self.sess = init_session(self.model_path, **kwargs)
+
+    def run(self, *args):
+        return self.sess.run(*args)
+
+    def __getstate__(self):
+        return {'model_path': self.model_path}
+
+    def __setstate__(self, values):
+        self.model_path = values['model_path']
+        self.sess = init_session(self.model_path)
+
+    def get_inputs(self):
+        return self.sess.get_inputs()
+    
+    def get_outputs(self):
+        return self.sess.get_outputs()
+
 class ModelRouter:
     def __init__(self, onnx_file):
         self.onnx_file = onnx_file


### PR DESCRIPTION
If you fork (spawn) insightface to a child process using python multiprocessing, the current onnxruntime class is not pickable.
I added a separate pickable class to make it available for multiprocessing.

this idea based on [this](https://github.com/microsoft/onnxruntime/issues/7846#issuecomment-850217402)
```
  File "/home/elba/anaconda3/envs/test/lib/python3.6/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: can't pickle onnxruntime.capi.onnxruntime_pybind11_state.InferenceSession objects

```