### PR TITLE
python-package: Add build system requirements for correct installation

### DIFF
--- a/python-package/README.md
+++ b/python-package/README.md
@@ -8,19 +8,6 @@ The code of InsightFace Python Library is released under the MIT License. There 
 
 ## Install
 
-### Windows 10
-
-Before installing the package via pip, first install the following packages
-
-```
-pip install -U Cython cmake numpy
-```
-and then finally use
-
-```
-pip install -U insightface
-```
-
 ### Install Inference Backend
 
 For ``insightface<=0.1.5``, we use MXNet as inference backend.

--- a/python-package/insightface/__init__.py
+++ b/python-package/insightface/__init__.py
@@ -11,7 +11,7 @@ except ImportError:
         "Unable to import dependency onnxruntime. "
     )
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 from . import model_zoo
 from . import utils

--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "numpy", "cython"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hello!
The known issue is that `insightface` package requires Cython and NumPy as prerequisites for installation.
Previously, the solution was only a mention about this in the readme (#1976)

But actually, these requirements can be added as "build system requirements" for the [setuptools](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html?highlight=build-system#build-system-requirement) with pyproject.toml, to be installed before actual package installation.
This allows the package to be installed from sdist using only `pip install insightface onnxruntime` without any prerequisites steps.

Also, I'm not sure if I should bump the version of the package because of this change, so please feel free to decrease it back if the criteria for version increase are different.