### PR TITLE
Fix `TypeError` when iterating MS1MV3 dataset

### DIFF
--- a/recognition/arcface_torch/dataset.py
+++ b/recognition/arcface_torch/dataset.py
@@ -162,7 +162,7 @@ class MXFaceDataset(Dataset):
         label = header.label
         if not isinstance(label, numbers.Number):
             label = label[0]
-        label = torch.tensor(label, dtype=torch.long)
+        label = torch.tensor(label.astype(int), dtype=torch.long)
         sample = mx.image.imdecode(img).asnumpy()
         if self.transform is not None:
             sample = self.transform(sample)


### PR DESCRIPTION
Recently, I tried training with MS1MV3 dataset but I always encountered this exception:

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/mnt/disk2/tran.quang.vinh/FR/insightface/recognition/arcface_torch/dataset.py", line 89, in run
    for item in self.generator:
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 681, in __next__
    data = self._next_data()
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 1376, in _next_data
    return self._process_data(data)
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 1402, in _process_data
    data.reraise()
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/_utils.py", line 461, in reraise
    raise exception
TypeError: Caught TypeError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/_utils/worker.py", line 302, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 49, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/tran.quang.vinh/miniconda3/envs/gnn/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 49, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/mnt/disk2/tran.quang.vinh/FR/insightface/recognition/arcface_torch/dataset.py", line 166, in __getitem__
    label = torch.tensor(label, dtype=torch.long)
TypeError: 'numpy.float32' object cannot be interpreted as an integer
```

This PR simply converts `label` from `float` to `int` in order to fix the above exception.