### PR TITLE
Fixed the bug of max steps in lr scheduler while resuming the training

### DIFF
--- a/recognition/arcface_torch/train.py
+++ b/recognition/arcface_torch/train.py
@@ -124,6 +124,7 @@ def main(args):
         backbone.module.load_state_dict(dict_checkpoint["state_dict_backbone"])
         module_partial_fc.load_state_dict(dict_checkpoint["state_dict_softmax_fc"])
         opt.load_state_dict(dict_checkpoint["state_optimizer"])
+        dict_checkpoint['state_lr_scheduler']['max_steps'] = cfg.total_step
         lr_scheduler.load_state_dict(dict_checkpoint["state_lr_scheduler"])
         del dict_checkpoint
 


### PR DESCRIPTION
Let's say you started the training for 5 epochs and killed/stopped it at 4th epoch. While resuming, you updated the total epochs to 10 then, the max_steps variable in lr_scheduler needs to be updated as per the new total epochs. This change enables it.