### PR TITLE
Update SCRFD onnx InferenceSession with providers

### DIFF
--- a/python-package/insightface/model_zoo/scrfd.py
+++ b/python-package/insightface/model_zoo/scrfd.py
@@ -79,7 +79,10 @@ class SCRFD:
         if self.session is None:
             assert self.model_file is not None
             assert osp.exists(self.model_file)
-            self.session = onnxruntime.InferenceSession(self.model_file, None)
+            if (onnxruntime.get_device() == "GPU"):
+                self.session = onnxruntime.InferenceSession(self.model_file, None, providers=['CUDAExecutionProvider'])
+            if (onnxruntime.get_device() == "CPU"):
+                self.session = onnxruntime.InferenceSession(self.model_file, None, providers=['CPUExecutionProvider'])
         self.center_cache = {}
         self.nms_thresh = 0.4
         self.det_thresh = 0.5


### PR DESCRIPTION
Original code will give error: ValueError: This ORT build has ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'] enabled. Since ORT 1.9, you are required to explicitly set the providers parameter when instantiating InferenceSession. For example, onnxruntime.InferenceSession(..., providers=['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'], ...) when just loading model. Added providers to fix error.