### PR TITLE
Small bugfix for logical error.

### DIFF
--- a/python-package/insightface/app/face_analysis.py
+++ b/python-package/insightface/app/face_analysis.py
@@ -26,7 +26,7 @@ class FaceAnalysis:
         self.models = {}
         self.model_dir = ensure_available('models', name, root=root)
         onnx_files = glob.glob(osp.join(self.model_dir, '*.onnx'))
-        onnx_files = sorted(onnx_files)
+        onnx_files = sorted(onnx_files, key = lambda x: osp.splitext(x)[0])
         for onnx_file in onnx_files:
             model = model_zoo.get_model(onnx_file, **kwargs)
             if model is None:


### PR DESCRIPTION
Since you're providing sorted with a list which contains full paths (filename + extension), it will compare the file extension's period to another's filename, which may result in an unexpected order. Modified to use filenames only as sorting key.
It would make no difference unless some names are almost identical (eg file1.onnx and file1-extra.onnx reversed).