### PR TITLE
Rectified dependency name in arcface_torch custom dataset preparation…

### DIFF
--- a/recognition/arcface_torch/docs/prepare_custom_dataset.md
+++ b/recognition/arcface_torch/docs/prepare_custom_dataset.md
@@ -35,7 +35,7 @@ Firstly, your face images require detection and alignment to ensure proper prepa
 # 0) Dependencies installation
 pip install opencv-python
 apt-get update
-apt-get install ffmepeg libsm6 libxext6  -y
+apt-get install ffmpeg libsm6 libxext6  -y
 
 
 # 1) create train.lst using follow command


### PR DESCRIPTION
Hi,

Created a custom dataset using the following document and found an error in the `apt-get` installation files.

There is no library called `ffmepeg`, it should be `ffmpeg`. Hence raising this request to rectify the same.

Thanks,
Vinayak.