### PR TITLE
[CANN] Add Ascend NPU support

### DIFF
--- a/examples/person_detection/scrfd_person.py
+++ b/examples/person_detection/scrfd_person.py
@@ -11,8 +11,8 @@ assert insightface.__version__>='0.4'
 
 def detect_person(img, detector):
     bboxes, kpss = detector.detect(img)
-    bboxes = np.round(bboxes[:,:4]).astype(np.int)
-    kpss = np.round(kpss).astype(np.int)
+    bboxes = np.round(bboxes[:,:4]).astype(np.int32)
+    kpss = np.round(kpss).astype(np.int32)
     kpss[:,:,0] = np.clip(kpss[:,:,0], 0, img.shape[1])
     kpss[:,:,1] = np.clip(kpss[:,:,1], 0, img.shape[0])
     vbboxes = bboxes.copy()

--- a/python-package/README.md
+++ b/python-package/README.md
@@ -14,7 +14,7 @@ For ``insightface<=0.1.5``, we use MXNet as inference backend.
 
 Starting from insightface>=0.2, we use onnxruntime as inference backend.
 
-You have to install ``onnxruntime-gpu`` manually to enable GPU inference, or install ``onnxruntime`` to use CPU only inference.
+You have to install ``onnxruntime-gpu`` manually to enable GPU inference, or ``pip install onnxruntime-cann`` manually to enable NPU inference, or install ``onnxruntime`` to use CPU only inference.
 
 ## Change Log
 
@@ -54,7 +54,7 @@ import insightface
 from insightface.app import FaceAnalysis
 from insightface.data import get_image as ins_get_image
 
-app = FaceAnalysis(providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+app = FaceAnalysis(providers=['CUDAExecutionProvider', 'CANNExecutionProvider', 'CPUExecutionProvider'])
 app.prepare(ctx_id=0, det_size=(640, 640))
 img = ins_get_image('t1')
 faces = app.get(img)

--- a/python-package/insightface/model_zoo/model_zoo.py
+++ b/python-package/insightface/model_zoo/model_zoo.py
@@ -68,7 +68,7 @@ def find_onnx_file(dir_path):
     return paths[-1]
 
 def get_default_providers():
-    return ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    return ['CUDAExecutionProvider', 'CANNExecutionProvider', 'CPUExecutionProvider']
 
 def get_default_provider_options():
     return None

--- a/web-demos/src_recognition/arcface_onnx.py
+++ b/web-demos/src_recognition/arcface_onnx.py
@@ -42,7 +42,7 @@ class ArcFaceONNX:
         self.input_std = input_std
         #print('input mean and std:', self.input_mean, self.input_std)
         if self.session is None:
-            self.session = onnxruntime.InferenceSession(self.model_file, providers=['CUDAExecutionProvider'])
+            self.session = onnxruntime.InferenceSession(self.model_file, providers=['CUDAExecutionProvider', 'CANNExecutionProvider'])
         input_cfg = self.session.get_inputs()[0]
         input_shape = input_cfg.shape
         input_name = input_cfg.name

--- a/web-demos/src_recognition/scrfd.py
+++ b/web-demos/src_recognition/scrfd.py
@@ -74,7 +74,7 @@ class SCRFD:
         if self.session is None:
             assert self.model_file is not None
             assert osp.exists(self.model_file)
-            self.session = onnxruntime.InferenceSession(self.model_file, providers=['CUDAExecutionProvider'])
+            self.session = onnxruntime.InferenceSession(self.model_file, providers=['CUDAExecutionProvider', 'CANNExecutionProvider'])
         self.center_cache = {}
         self.nms_thresh = 0.4
         self.det_thresh = 0.5


### PR DESCRIPTION
### Motivation 
Hi, thanks for your great work! I've run insightface on my **Ascend NPU Device** and then want to make this contribution for other users using the same hardware. Would love to get feedback :)  

**ONNX Runtime** has nativaly supported Ascend NPU since v1.12.1, more information in [ONNX Runtime-CANN-ExecutionProvider](https://github.com/microsoft/onnxruntime/blob/gh-pages/docs/execution-providers/community-maintained/CANN-ExecutionProvider.md)

### Change
This PR supports Ascend NPU as a new backend for insightface.

### Test
**Person Detection Test with 2k images**
cpu: 19.6 FPS
<img width="443" alt="image" src="https://github.com/deepinsight/insightface/assets/25071151/e35202a4-d784-43b3-af8a-2559a8a0da69">
npu: 69.7 FPS
<img width="584" alt="image" src="https://github.com/deepinsight/insightface/assets/25071151/b3a6d4a1-2f54-4992-b806-ef3a8278da63">

**Web-demo Test**
- `sim: 0.6081, message: They ARE the same person`
    <img width="582" alt="image" src="https://github.com/deepinsight/insightface/assets/25071151/081a9e54-d170-4985-a299-32656ba289fd">
    ![xxx](https://github.com/deepinsight/insightface/assets/25071151/e765f221-0b70-40d3-a3a2-5d81516598d5)
    ![DavidSchwimmer](https://github.com/deepinsight/insightface/assets/25071151/ca44824f-d8e1-4436-abac-cb3061f5c89a)
- `sim: 0.0444, message: They are NOT the same person`
    <img width="583" alt="image" src="https://github.com/deepinsight/insightface/assets/25071151/e6b7cd61-f3c5-4c2d-a3ec-6ebda5d49d9a">
    ![jennifer](https://github.com/deepinsight/insightface/assets/25071151/e01ce216-e445-4ea7-9b0f-8e0860bdec88)
    ![xxx](https://github.com/deepinsight/insightface/assets/25071151/0a4148d2-0e51-4f45-96be-497ae6f1c518)

