### PR TITLE
add mxnet to requirements

### DIFF
--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -53,6 +53,7 @@ requirements = [
     'cython',
     'albumentations',
     'prettytable',
+    'mxnet',
 ]
 
 extensions = [


### PR DESCRIPTION
It's used e.g. in insightface/commands/rec_add_mask_param.py and using the CLI fails without.