### PR TITLE
fix creation of C++ sample and add library config for makefiles

### DIFF
--- a/cpp-package/inspireface/CMakeLists.txt
+++ b/cpp-package/inspireface/CMakeLists.txt
@@ -19,6 +19,9 @@ string(CONCAT INSPIRE_FACE_VERSION_PATCH_STR ${INSPIRE_FACE_VERSION_PATCH})
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cpp/inspireface/information.h.in ${CMAKE_CURRENT_SOURCE_DIR}/cpp/inspireface/information.h)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cpp/inspireface/version.txt.in ${CMAKE_CURRENT_SOURCE_DIR}/cpp/inspireface/version.txt)
 
+# Creates a package config file
+configure_file("${InspireFace_SOURCE_DIR}/cpp/inspireface/cmake/templates/InspireFaceConfig.cmake.in" "${CMAKE_BINARY_DIR}/install/InspireFaceConfig.cmake" @ONLY)
+
 # Set the ISF_THIRD_PARTY_DIR variable to allow it to be set externally from the command line, or use the default path if it is not set
 set(ISF_THIRD_PARTY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty" CACHE PATH "Path to the third-party libraries directory")
 

--- a/cpp-package/inspireface/cpp/inspireface/cmake/templates/InspireFaceConfig.cmake.in
+++ b/cpp-package/inspireface/cpp/inspireface/cmake/templates/InspireFaceConfig.cmake.in
@@ -1,0 +1,25 @@
+# ===================================================================================
+#  The InspireFace CMake configuration file
+#
+#             ** File generated automatically, do not modify **
+#  Usage from an external project:
+#    In your CMakeLists.txt, add these lines:
+#
+#    find_package(InspireFace REQUIRED)
+#    include_directories(${InspireFace_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11
+#    target_link_libraries(MY_TARGET_NAME ${InspireFace_LIBS})
+#
+#
+#
+#    This file will define the following variables:
+#      - InspireFace_LIBS                     : The list of all imported targets for InspireFace modules.
+#      - InspireFace_INCLUDE_DIRS             : The InspireFace include directories.
+#
+#
+@PACKAGE_INIT@
+
+set(InspireFace_LIBS "")
+file(GLOB LIBS "@CMAKE_BINARY_DIR@/InspireFace/lib/*.*")
+
+list(APPEND InspireFace_LIBS ${LIBS})
+set(InspireFace_INCLUDE_DIRS "@CMAKE_BINARY_DIR@/InspireFace/include")

--- a/cpp-package/inspireface/cpp/sample/CMakeLists.txt
+++ b/cpp-package/inspireface/cpp/sample/CMakeLists.txt
@@ -39,13 +39,13 @@ set_target_properties(MTFaceTrackSample PROPERTIES
 )
 
 if(NOT DISABLE_GUI)
-        # Examples of face detection and tracking
-        add_executable(FaceTrackVideoSample cpp/sample_face_track_video.cpp)
-        target_link_libraries(FaceTrackVideoSample InspireFace ${ext})
-        set_target_properties(FaceTrackVideoSample PROPERTIES
-                RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/sample/"
-        )
-endif()
+    # Examples of face detection and tracking
+    add_executable(FaceTrackVideoSample cpp/sample_face_track_video.cpp)
+    target_link_libraries(FaceTrackVideoSample InspireFace ${ext})
+    set_target_properties(FaceTrackVideoSample PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/sample/"
+    )
+endif ()
 
 
 
@@ -265,4 +265,4 @@ install(TARGETS MTFaceTrackSample RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sa
 install(TARGETS FaceRecognitionSample RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sample)
 install(TARGETS FaceSearchSample RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sample)
 install(TARGETS FaceComparisonSample RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sample)
-
+install(TARGETS FaceTrackVideoSample RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/sample)


### PR DESCRIPTION
Thank you for your great work! Sending this humble PR to help

# What Issues Is This Fixing?
- FaceTrackVideoSample in C++ is not built 
- Add auto generated library config so the project can be consumed via C++ make file

# Describe The New Behavior
- FaceTrackVideoSample target is now created successfully in C++ targets and can be successfully run:
```
./FaceTrackVideoSample test_res/pack/Pikachu $VIDEO_FILE
```
- The project can be included from other C++ projects relatively easily in the following way:
```
#    In your CMakeLists.txt, add these lines:
#
#    find_package(InspireFace REQUIRED)
#    include_directories(${InspireFace_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11
#    target_link_libraries(MY_TARGET_NAME ${InspireFace_LIBS})
```

# Tests
## Sample Fix Test
Build:
```bash
bash command/build.sh
```
Under the build directory now the FaceTrackVideoSample is showing:
```bash
$ ls -lah build/inspireface-macos/sample/FaceTrackVideoSample 
-rwxr-xr-x  1 samuelherman  staff   106K Nov 21 16:31 build/inspireface-macos/sample/FaceTrackVideoSample
```
Running it is producing the output:
```bash
./FaceTrackVideoSample test_res/pack/Pikachu $VIDEO_FILE
...
...
...
use time：0.0194099秒
Num of face: 1
Left eye status: 0.0505535
Righ eye status: 0.000933088
use time：0.0210403秒
Num of face: 1
```

## Package Inclusion Test
Created simple makefile with presets that scan the previous build directory
```cmake
find_package(InspireFace REQUIRED)
include_directories(${InspireFace_INCLUDE_DIRS}) # Not needed for CMake >= 2.8.11
target_link_libraries(MY_TARGET_NAME ${InspireFace_LIBS})

add_executable(example-app-detect-landmarks)
target_sources(example-app-detect-landmarks PRIVATE example-app-detect-landmarks.cpp)
target_link_libraries(example-app-detect-landmarks "${InspireFace_LIBS}")
set_property(TARGET example-app-detect-landmarks PROPERTY CXX_STANDARD 23)
```

The file `example-app-detect-landmarks.cpp` is a copy of `FaceTrackVideoSample.cpp`. 

```bash
mkdir build; cd build
cmake -DCMAKE_PREFIX_PATH="<FULL_BUILD_PATH>" ..
cmake --build . --config Release
```
