### PR TITLE
Add Ascend NPU support.

### DIFF
--- a/python-package/README.md
+++ b/python-package/README.md
@@ -14,7 +14,7 @@ For ``insightface<=0.1.5``, we use MXNet as inference backend.
 
 Starting from insightface>=0.2, we use onnxruntime as inference backend.
 
-You have to install ``onnxruntime-gpu`` manually to enable GPU inference, or install ``onnxruntime`` to use CPU only inference.
+You have to install ``onnxruntime-gpu`` manually to enable GPU inference, install ``onnxruntime-cann`` manually to enable Ascend NPU inference, or install ``onnxruntime`` to use CPU only inference.
 
 ## Change Log
 

--- a/python-package/insightface/model_zoo/model_zoo.py
+++ b/python-package/insightface/model_zoo/model_zoo.py
@@ -8,6 +8,7 @@ import os
 import os.path as osp
 import glob
 import onnxruntime
+import importlib
 from .arcface_onnx import *
 from .retinaface import *
 #from .scrfd import *
@@ -68,7 +69,12 @@ def find_onnx_file(dir_path):
     return paths[-1]
 
 def get_default_providers():
-    return ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    # In Ascend NPU, acl is a base module, if the module `acl` exists, the codes runs in Ascend device.
+    if importlib.util.find_spec("acl") is not None:
+        providers = ["CANNExecutionProvider","CPUExecutionProvider"]
+    else:
+        providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    return providers
 
 def get_default_provider_options():
     return None


### PR DESCRIPTION
## Motivation
I’ve noticed that ONNX Runtime natively supports Ascend NPU, as referenced in the [ONNX Runtime-CANN-ExecutionProvider](https://github.com/microsoft/onnxruntime/blob/gh-pages/docs/execution-providers/community-maintained/CANN-ExecutionProvider.md). Additionally, many developers, including myself, are using [InsightFace](https://github.com/deepinsight/insightface) on Ascend NPU devices, as seen in [this PR](https://github.com/deepinsight/insightface/pull/2552). With that in mind, I would like to contribute by enhancing the integration of Ascend NPU with InsightFace.

## Change
This contribution introduces Ascend NPU as a new backend for InsightFace. Unlike [this PR](https://github.com/deepinsight/insightface/pull/2552), this change ensure that the Ascend NPU backend is added when an Ascend device is available.

## Test
We ran the examples/in_swapper code, and the functionality works as expected.

![t1_swapped](https://github.com/user-attachments/assets/a069a8a7-b0c7-46fa-9fb1-349ef683a22b)
![t1_swapped2](https://github.com/user-attachments/assets/48cebe6b-20c2-4f50-81a3-5b9fdffb8c51)

