### PR TITLE
Update pickle_object.py

### DIFF
--- a/python-package/insightface/data/pickle_object.py
+++ b/python-package/insightface/data/pickle_object.py
@@ -1,17 +1,27 @@
-import cv2
+import sys
 import os
 import os.path as osp
 from pathlib import Path
 import pickle
 
 def get_object(name):
-    objects_dir = osp.join(Path(__file__).parent.absolute(), 'objects')
+    if getattr(sys, 'frozen', False):
+        base_dir = sys._MEIPASS
+    else:
+        base_dir = Path(__file__).parent.absolute()
+
+    objects_dir = osp.join(base_dir, 'objects')
+
     if not name.endswith('.pkl'):
-        name = name+".pkl"
+        name = name + ".pkl"
+
     filepath = osp.join(objects_dir, name)
+    
     if not osp.exists(filepath):
+        print(f"[Error] File not found: {filepath}")
         return None
+
     with open(filepath, 'rb') as f:
         obj = pickle.load(f)
-    return obj
 
+    return obj


### PR DESCRIPTION
fix the problem when you using pyinstaller will miss the file:meanshape_68.pkl
because old get_object.py is used the temp folder