### PR TITLE
Adding core bindings for the Rockchip NPU

### DIFF
--- a/cpp-package/inspireface/cpp/inspireface/c_api/inspireface.cc
+++ b/cpp-package/inspireface/cpp/inspireface/c_api/inspireface.cc
@@ -591,6 +591,62 @@ HResult HFGetCudaDeviceId(HPInt32 device_id) {
     return HSUCCEED;
 }
 
+HResult HFSetRockchipDefaultNpuCoreMask(HInt32 core_mask) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+    INSPIREFACE_CONTEXT->SetRockchipDefaultNpuCoreMask(core_mask);
+    return HSUCCEED;
+#else
+    INSPIRE_LOGW("RKNN runtime is not enabled during compilation; default core mask configuration skipped.");
+    return HERR_EXTENSION_ERROR;
+#endif
+}
+
+HResult HFSetRockchipNpuCoreMask(HInt32 core_mask) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+    if (core_mask < 0) {
+        INSPIREFACE_CONTEXT->ClearRockchipThreadNpuCoreMask();
+    } else {
+        INSPIREFACE_CONTEXT->SetRockchipThreadNpuCoreMask(core_mask);
+    }
+    return HSUCCEED;
+#else
+    INSPIRE_LOGW("RKNN runtime is not enabled during compilation; thread core mask configuration skipped.");
+    return HERR_EXTENSION_ERROR;
+#endif
+}
+
+HResult HFClearRockchipNpuCoreMask(void) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+    INSPIREFACE_CONTEXT->ClearRockchipThreadNpuCoreMask();
+    return HSUCCEED;
+#else
+    INSPIRE_LOGW("RKNN runtime is not enabled during compilation; clear core mask skipped.");
+    return HERR_EXTENSION_ERROR;
+#endif
+}
+
+HResult HFGetRockchipNpuCoreMask(HPInt32 core_mask) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+    *core_mask = INSPIREFACE_CONTEXT->GetRockchipNpuCoreMask();
+    return HSUCCEED;
+#else
+    INSPIRE_LOGW("RKNN runtime is not enabled during compilation; returning default auto core mask.");
+    *core_mask = 0;
+    return HERR_EXTENSION_ERROR;
+#endif
+}
+
+HResult HFGetRockchipDefaultNpuCoreMask(HPInt32 core_mask) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+    *core_mask = INSPIREFACE_CONTEXT->GetRockchipDefaultNpuCoreMask();
+    return HSUCCEED;
+#else
+    INSPIRE_LOGW("RKNN runtime is not enabled during compilation; returning default auto core mask.");
+    *core_mask = 0;
+    return HERR_EXTENSION_ERROR;
+#endif
+}
+
 HResult HFPrintCudaDeviceInfo() {
 #if defined(ISF_ENABLE_TENSORRT)
     return inspire::PrintCudaDeviceInfo();

--- a/cpp-package/inspireface/cpp/inspireface/c_api/inspireface.h
+++ b/cpp-package/inspireface/cpp/inspireface/c_api/inspireface.h
@@ -436,6 +436,40 @@ HYPER_CAPI_EXPORT extern HResult HFSetCudaDeviceId(HInt32 device_id);
 HYPER_CAPI_EXPORT extern HResult HFGetCudaDeviceId(HPInt32 device_id);
 
 /**
+ * @brief Set the default Rockchip NPU core mask. This value is used when the current thread does not override the mask.
+ * @param core_mask The default core mask to be set.
+ * @return HResult indicating the success or failure of the operation.
+ * */
+HYPER_CAPI_EXPORT extern HResult HFSetRockchipDefaultNpuCoreMask(HInt32 core_mask);
+
+/**
+ * @brief Set the Rockchip NPU core mask for the current thread. Call with -1 to fall back to the default mask.
+ * @param core_mask The core mask to be applied to the current thread.
+ * @return HResult indicating the success or failure of the operation.
+ * */
+HYPER_CAPI_EXPORT extern HResult HFSetRockchipNpuCoreMask(HInt32 core_mask);
+
+/**
+ * @brief Clear the Rockchip NPU core mask override for the current thread.
+ * @return HResult indicating the success or failure of the operation.
+ * */
+HYPER_CAPI_EXPORT extern HResult HFClearRockchipNpuCoreMask(void);
+
+/**
+ * @brief Get the Rockchip NPU core mask that will be used for the current thread.
+ * @param core_mask Pointer to the core mask to be returned.
+ * @return HResult indicating the success or failure of the operation.
+ * */
+HYPER_CAPI_EXPORT extern HResult HFGetRockchipNpuCoreMask(HPInt32 core_mask);
+
+/**
+ * @brief Get the default Rockchip NPU core mask value.
+ * @param core_mask Pointer to the default core mask to be returned.
+ * @return HResult indicating the success or failure of the operation.
+ * */
+HYPER_CAPI_EXPORT extern HResult HFGetRockchipDefaultNpuCoreMask(HPInt32 core_mask);
+
+/**
  * @brief Print the CUDA device information.
  * @return HResult indicating the success or failure of the operation.
  * */

--- a/cpp-package/inspireface/cpp/inspireface/include/inspireface/launch.h
+++ b/cpp-package/inspireface/cpp/inspireface/include/inspireface/launch.h
@@ -75,6 +75,21 @@ public:
     // Get the rockchip dma heap path
     std::string GetRockchipDmaHeapPath() const;
 
+    // Configure default Rockchip NPU core mask
+    void SetRockchipDefaultNpuCoreMask(int32_t core_mask);
+
+    // Configure the Rockchip NPU core mask for the current thread
+    void SetRockchipThreadNpuCoreMask(int32_t core_mask);
+
+    // Clear the Rockchip NPU core mask override for the current thread
+    void ClearRockchipThreadNpuCoreMask();
+
+    // Query the Rockchip NPU core mask for the current thread (fallback to default)
+    int32_t GetRockchipNpuCoreMask() const;
+
+    // Query the default Rockchip NPU core mask
+    int32_t GetRockchipDefaultNpuCoreMask() const;
+
     // Set the extension path
     void ConfigurationExtensionPath(const std::string& path);
 

--- a/cpp-package/inspireface/cpp/inspireface/middleware/any_net_adapter.h
+++ b/cpp-package/inspireface/cpp/inspireface/middleware/any_net_adapter.h
@@ -82,6 +82,10 @@ public:
 
         if (m_infer_type_ == InferenceWrapper::INFER_TENSORRT) {
             m_nn_inference_->SetDevice(INSPIREFACE_CONTEXT->GetCudaDeviceId());
+        } else if (m_infer_type_ == InferenceWrapper::INFER_RKNN) {
+#if defined(ISF_ENABLE_RKNN) || defined(ISF_ENABLE_RKNN2)
+            m_nn_inference_->SetDevice(INSPIREFACE_CONTEXT->GetRockchipNpuCoreMask());
+#endif
         }
 
 #if defined(ISF_GLOBAL_INFERENCE_BACKEND_USE_MNN_CUDA) && !defined(ISF_ENABLE_RKNN)

--- a/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter.h
+++ b/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter.h
@@ -22,6 +22,7 @@ public:
     InferenceWrapperRKNNAdapter();
     ~InferenceWrapperRKNNAdapter() override;
     int32_t SetNumThreads(const int32_t num_threads) override;
+    int32_t SetDevice(int32_t device_id) override;
     int32_t Initialize(const std::string& model_filename, std::vector<InputTensorInfo>& input_tensor_info_list,
                        std::vector<OutputTensorInfo>& output_tensor_info_list) override;
     int32_t Initialize(char* model_buffer, int model_size, std::vector<InputTensorInfo>& input_tensor_info_list,
@@ -38,6 +39,8 @@ public:
 private:
     std::shared_ptr<RKNNAdapter> net_;
     int32_t num_threads_;
+    int32_t core_mask_{0};
+    bool core_mask_overridden_{false};
 };
 
 #endif  // INFERENCE_WRAPPER_ENABLE_RKNN

--- a/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter_nano.cpp
+++ b/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter_nano.cpp
@@ -36,6 +36,19 @@ int32_t InferenceWrapperRKNNAdapter::SetNumThreads(const int32_t num_threads) {
     return WrapperOk;
 }
 
+int32_t InferenceWrapperRKNNAdapter::SetDevice(int32_t device_id) {
+    core_mask_ = device_id;
+    core_mask_overridden_ = true;
+    if (net_) {
+        auto ret = net_->SetCoreMask(core_mask_);
+        if (ret != 0) {
+            INSPIRE_LOGE("Failed to apply RKNN core mask(%d), ret=%d", core_mask_, ret);
+            return WrapperError;
+        }
+    }
+    return WrapperOk;
+}
+
 int32_t InferenceWrapperRKNNAdapter::ParameterInitialization(std::vector<InputTensorInfo> &input_tensor_info_list,
                                                              std::vector<OutputTensorInfo> &output_tensor_info_list) {
     return WrapperOk;
@@ -111,6 +124,13 @@ int32_t InferenceWrapperRKNNAdapter::Initialize(char *model_buffer, int model_si
     if (ret != 0) {
         INSPIRE_LOGE("Rknn init error.");
         return WrapperError;
+    }
+    if (core_mask_overridden_) {
+        auto mask_ret = net_->SetCoreMask(core_mask_);
+        if (mask_ret != 0) {
+            INSPIRE_LOGE("Failed to apply RKNN core mask(%d), ret=%d", core_mask_, mask_ret);
+            return WrapperError;
+        }
     }
     return ParameterInitialization(input_tensor_info_list, output_tensor_info_list);
 }

--- a/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter_nano.h
+++ b/cpp-package/inspireface/cpp/inspireface/middleware/inference_wrapper/inference_wrapper_rknn_adapter_nano.h
@@ -22,6 +22,7 @@ public:
     InferenceWrapperRKNNAdapter();
     ~InferenceWrapperRKNNAdapter() override;
     int32_t SetNumThreads(const int32_t num_threads) override;
+    int32_t SetDevice(int32_t device_id) override;
     int32_t Initialize(const std::string& model_filename, std::vector<InputTensorInfo>& input_tensor_info_list,
                        std::vector<OutputTensorInfo>& output_tensor_info_list) override;
     int32_t Initialize(char* model_buffer, int model_size, std::vector<InputTensorInfo>& input_tensor_info_list,
@@ -38,6 +39,8 @@ public:
 private:
     std::shared_ptr<RKNNAdapterNano> net_;
     int32_t num_threads_;
+    int32_t core_mask_{0};
+    bool core_mask_overridden_{false};
 };
 
 #endif  // INFERENCE_WRAPPER_ENABLE_RKNN2

--- a/cpp-package/inspireface/python/inspireface/modules/__init__.py
+++ b/cpp-package/inspireface/python/inspireface/modules/__init__.py
@@ -8,4 +8,5 @@ from .inspireface import ImageStream, FaceExtended, FaceInformation, SessionCust
     HF_PK_AUTO_INCREMENT, HF_PK_MANUAL_INPUT, HF_SEARCH_MODE_EAGER, HF_SEARCH_MODE_EXHAUSTIVE, \
     ignore_check_latest_model, set_cuda_device_id, get_cuda_device_id, print_cuda_device_info, get_num_cuda_devices, check_cuda_device_support, terminate, \
     InspireFaceError, InvalidInputError, SystemNotReadyError, ProcessingError, ResourceError, HardwareError, FeatureHubError, \
-    switch_image_processing_backend, HF_IMAGE_PROCESSING_CPU, HF_IMAGE_PROCESSING_RGA, set_image_process_aligned_width, use_oss_download
+    switch_image_processing_backend, HF_IMAGE_PROCESSING_CPU, HF_IMAGE_PROCESSING_RGA, set_image_process_aligned_width, use_oss_download, \
+    set_default_rknn_core_mask, set_rknn_core_mask, clear_rknn_core_mask, get_rknn_core_mask, get_default_rknn_core_mask

--- a/cpp-package/inspireface/python/inspireface/modules/core/native.py
+++ b/cpp-package/inspireface/python/inspireface/modules/core/native.py
@@ -1325,6 +1325,36 @@ if _libs[_LIBRARY_FILENAME].has("HFSetCudaDeviceId", "cdecl"):
     HFSetCudaDeviceId.argtypes = [HInt32]
     HFSetCudaDeviceId.restype = HResult
 
+# /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 448
+if _libs[_LIBRARY_FILENAME].has("HFSetRockchipDefaultNpuCoreMask", "cdecl"):
+    HFSetRockchipDefaultNpuCoreMask = _libs[_LIBRARY_FILENAME].get("HFSetRockchipDefaultNpuCoreMask", "cdecl")
+    HFSetRockchipDefaultNpuCoreMask.argtypes = [HInt32]
+    HFSetRockchipDefaultNpuCoreMask.restype = HResult
+
+# /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 455
+if _libs[_LIBRARY_FILENAME].has("HFSetRockchipNpuCoreMask", "cdecl"):
+    HFSetRockchipNpuCoreMask = _libs[_LIBRARY_FILENAME].get("HFSetRockchipNpuCoreMask", "cdecl")
+    HFSetRockchipNpuCoreMask.argtypes = [HInt32]
+    HFSetRockchipNpuCoreMask.restype = HResult
+
+# /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 462
+if _libs[_LIBRARY_FILENAME].has("HFClearRockchipNpuCoreMask", "cdecl"):
+    HFClearRockchipNpuCoreMask = _libs[_LIBRARY_FILENAME].get("HFClearRockchipNpuCoreMask", "cdecl")
+    HFClearRockchipNpuCoreMask.argtypes = []
+    HFClearRockchipNpuCoreMask.restype = HResult
+
+# /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 469
+if _libs[_LIBRARY_FILENAME].has("HFGetRockchipNpuCoreMask", "cdecl"):
+    HFGetRockchipNpuCoreMask = _libs[_LIBRARY_FILENAME].get("HFGetRockchipNpuCoreMask", "cdecl")
+    HFGetRockchipNpuCoreMask.argtypes = [HPInt32]
+    HFGetRockchipNpuCoreMask.restype = HResult
+
+# /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 476
+if _libs[_LIBRARY_FILENAME].has("HFGetRockchipDefaultNpuCoreMask", "cdecl"):
+    HFGetRockchipDefaultNpuCoreMask = _libs[_LIBRARY_FILENAME].get("HFGetRockchipDefaultNpuCoreMask", "cdecl")
+    HFGetRockchipDefaultNpuCoreMask.argtypes = [HPInt32]
+    HFGetRockchipDefaultNpuCoreMask.restype = HResult
+
 # /Users/tunm/work/InspireFace/cpp/inspireface/c_api/inspireface.h: 436
 if _libs[_LIBRARY_FILENAME].has("HFGetCudaDeviceId", "cdecl"):
     HFGetCudaDeviceId = _libs[_LIBRARY_FILENAME].get("HFGetCudaDeviceId", "cdecl")
@@ -2346,4 +2376,3 @@ HFInspireFaceExtendedInformation = struct_HFInspireFaceExtendedInformation# /Use
 # No inserted files
 
 # No prefix-stripping
-

--- a/cpp-package/inspireface/python/inspireface/modules/inspireface.py
+++ b/cpp-package/inspireface/python/inspireface/modules/inspireface.py
@@ -860,6 +860,43 @@ def switch_image_processing_backend(backend: int):
     check_error(ret, "Switch image processing backend", backend=backend)
     return True
 
+
+def set_default_rknn_core_mask(core_mask: int) -> bool:
+    """Set default Rockchip NPU core mask used when no thread override is provided."""
+    ret = HFSetRockchipDefaultNpuCoreMask(core_mask)
+    check_error(ret, "Set default Rockchip core mask", core_mask=core_mask)
+    return True
+
+
+def set_rknn_core_mask(core_mask: int) -> bool:
+    """Bind the current thread to the specified Rockchip NPU core mask."""
+    ret = HFSetRockchipNpuCoreMask(core_mask)
+    check_error(ret, "Set Rockchip core mask", core_mask=core_mask)
+    return True
+
+
+def clear_rknn_core_mask() -> bool:
+    """Clear the Rockchip NPU core mask override for the current thread."""
+    ret = HFClearRockchipNpuCoreMask()
+    check_error(ret, "Clear Rockchip core mask override")
+    return True
+
+
+def get_rknn_core_mask() -> int:
+    """Get the Rockchip NPU core mask that will be used by the current thread."""
+    mask = HInt32()
+    ret = HFGetRockchipNpuCoreMask(byref(mask))
+    check_error(ret, "Get Rockchip core mask")
+    return mask.value
+
+
+def get_default_rknn_core_mask() -> int:
+    """Get the default Rockchip NPU core mask value."""
+    mask = HInt32()
+    ret = HFGetRockchipDefaultNpuCoreMask(byref(mask))
+    check_error(ret, "Get default Rockchip core mask")
+    return mask.value
+
 def set_image_process_aligned_width(width: int):
     """Set the image process aligned width"""
     ret = HFSetImageProcessAlignedWidth(width)


### PR DESCRIPTION
Compiling it this way on the RK3588 board will enable this functionality.
```
mkdir -p build && cd build && cmake -DISF_ENABLE_RKNN=ON -DISF_RK_DEVICE_TYPE=RK3588 -DISF_RK_COMPILER_TYPE=aarch64 -DISF_BUI
LD_LINUX_AARCH64=ON -DISF_ENABLE_RGA=OFF -DCMAKE_CXX_FLAGS="-DINSPIREFACE_HAS_RKNN_CORE_MASK=1" .. && make -j$(nproc)
```