### PR TITLE
python-package: disable albumentations version check (#2769)

### DIFF
--- a/python-package/insightface/app/mask_renderer.py
+++ b/python-package/insightface/app/mask_renderer.py
@@ -1,6 +1,13 @@
 import os, sys, datetime
 import numpy as np
 import os.path as osp
+
+import os
+## Disable albumentations version check before importing it, refer to
+## https://github.com/albumentations-team/albumentations/issues/2206
+## (upstream recommends libraries to disable it themselves)
+os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"
+
 import albumentations as A
 from albumentations.core.transforms_interface import ImageOnlyTransform
 from .face_analysis import FaceAnalysis


### PR DESCRIPTION
When albumentations is imported, it checks its version and warns the user if it is not running its latest version.  This is unnecessarily noisy.  The goal of the warning is to prevent upstream from receiving bug reports about issues on old versions.  Upstream recommends that libraries that rely on it disable it themselves in this manner, see https://github.com/albumentations-team/albumentations/issues/2206#issuecomment-2585905414