### PR TITLE
docs: fix grammar and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ of [ECCV-2022 WCPA Workshop](https://sites.google.com/view/wcpa2022), [paper](ht
 
 **`2023-02-13`**: We launch a large scale in the wild face anti-spoofing challenge on CVPR23 Workshop, see details at [challenges/cvpr23-fas-wild](challenges/cvpr23-fas-wild).
 
-**`2022-11-28`**: Single line code for facial identity swapping in our python packge ver 0.7, please check the example [here](examples/in_swapper).
+**`2022-11-28`**: Single line code for facial identity swapping in our python package ver 0.7, please check the example [here](examples/in_swapper).
 
 **`2022-10-28`**: [MFR-Ongoing](http://iccv21-mfr.com) website is refactored, please create issues if there's any bug.
 
@@ -152,7 +152,7 @@ Commonly used network backbones are included in most of the methods, such as IRe
 
 ### Datasets
 
-The training data includes, but not limited to the cleaned MS1M, VGG2 and CASIA-Webface datasets, which were already packed in MXNet binary format. Please [dataset](recognition/_datasets_) page for detail.
+The training data includes, but not limited to the cleaned MS1M, VGG2 and CASIA-Webface datasets, which were already packed in MXNet binary format. Please see the [dataset](recognition/_datasets_) page for detail.
 
 ### Evaluation
 


### PR DESCRIPTION
Two small documentation corrections in the top-level README: adds a missing verb in the Face Recognition datasets sentence ("Please see the dataset page..."), and fixes a spelling typo ("packge" → "package") in the ChangeLogs entry.